### PR TITLE
수정해야할 dmtq.db3 경로 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ $ mv /home/ubuntu/DMTQ-server/www.neonapi.com/api/accounts_server/ /home/ubuntu/
 
 ```sh
 $ cd ~
-$ sed -i 's#C:.dmtq.db3#/home/ubuntu/DMTQ-server/_info/dmtq.db3#' DMTQ-server/dmqglb.mb.pmang.com/score/index.php DMTQ-server/dmqglb.mb.pmang.com/djmaxQ/_vendor/_config.php DMTQ-server/pmangplus.com/accounts/v3/global/login_dmq.php DMTQ-server/www.neonapi.com/api/accounts/v3/global/login_dmq.php
+$ sed -i 's#C:.dmtq.db3#/home/ubuntu/DMTQ-server/_info/dmtq.db3#' DMTQ-server/dmqglb.mb.pmang.com/score/index.php DMTQ-server/dmqglb.mb.pmang.com/djmaxQ/_vendor/_config.php DMTQ-server/pmangplus.com/accounts/v3/global/login_dmq.php DMTQ-server/www.neonapi.com/api/accounts/v3/global/login_dmq.php DMTQ-server/_vendor/config.php
 ```
 
 아래 명령어 수행하여 디비파일에 쓰기권한을 준다.


### PR DESCRIPTION
안녕하세요. 오래전 이 레포 덕분에 구동 성공하였습니다. 감사합니다.
근데 `DMTQ-server/_vendor/config.php`에서도 dmtq.db3 경로를 수정해야 구동이 됩니다.
이외에는 docker위 ubuntu jammy(22.04 LTS)에서 명령어만 치고 아이패드에서 구동 확인했습니다.
좋은 레포 감사합니다.